### PR TITLE
Removal of some warnings, changed some default values and extra comments for easier configuration

### DIFF
--- a/Sensirion.cpp
+++ b/Sensirion.cpp
@@ -98,10 +98,14 @@ Sensirion::Sensirion(uint8_t dataPin, uint8_t clockPin) {
 uint8_t Sensirion::measure(float *temp, float *humi, float *dew) {
   uint16_t rawData;
   uint8_t error;
-  if (error = measTemp(&rawData))
+
+  error = measTemp(&rawData);
+  if (error)
     return error;
   *temp = calcTemp(rawData);
-  if (error = measHumi(&rawData))
+  
+  error = measHumi(&rawData);
+  if (error)
     return error;
   *humi = calcHumi(rawData, *temp);
   *dew = calcDewpoint(*humi, *temp);
@@ -119,7 +123,9 @@ uint8_t Sensirion::meas(uint8_t cmd, uint16_t *result, bool block) {
     cmd = MEAS_TEMP;
   else
     cmd = MEAS_HUMI;
-  if (error = putByte(cmd))
+
+  error = putByte(cmd);
+  if (error)
     return error;
 #ifdef CRC_ENA
   calcCRC(cmd, &_crc);              // Include command byte in CRC calculation
@@ -185,7 +191,8 @@ uint8_t Sensirion::writeSR(uint8_t value) {
   value &= SR_MASK;                 // Mask off unwritable bits
   _stat_reg = value;                // Save local copy
   startTransmission();
-  if (error = putByte(STAT_REG_W))
+  error = putByte(STAT_REG_W);
+  if (error)
     return error;
   return putByte(value);
 }
@@ -198,7 +205,8 @@ uint8_t Sensirion::readSR(uint8_t *result) {
   _crc = bitrev(_stat_reg & SR_MASK);  // Initialize CRC calculation
 #endif
   startTransmission();
-  if (error = putByte(STAT_REG_R)) {
+  error = putByte(STAT_REG_R);
+  if (error) {
     *result = 0xFF;
     return error;
   }

--- a/Sensirion.h
+++ b/Sensirion.h
@@ -39,7 +39,7 @@ const bool    BLOCK    =  true;
 const bool    NONBLOCK = false;
 
 // Status register bit definitions
-const uint8_t LOW_RES  =  0x01;  // 12-bit Temp / 8-bit RH (vs. 14 / 12)
+const uint8_t LOW_RES  =  0x00;  // 0x01: 12-bit Temp/ 8-bit RH (vs. 0x00: 14-bit/ 12-bit)
 const uint8_t NORELOAD =  0x02;  // No reload of calibrarion data
 const uint8_t HEAT_ON  =  0x04;  // Built-in heater on
 const uint8_t BATT_LOW =  0x40;  // VDD < 2.47V


### PR DESCRIPTION
Removed compiler warnings because of variable assignment inside some if statement conditions, also changed default resolution to high and added comment for high/low resolution configuration values.