### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=Sensirion
+version=2.0.1
+author=Markus Schatzl, Carl Jackson
+maintainer=spease
+sentence=For the Sensirion SHT1x and SHT7x family of temperature and humidity sensors.
+paragraph=
+category=Sensors
+url=https://github.com/spease/Sensirion
+architectures=*
+includes=Sensirion.h


### PR DESCRIPTION
This file is required for inclusion in the Arduino Library Manager index.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata

Partially resolves https://github.com/spease/Sensirion/issues/3